### PR TITLE
fix: add reference to clarify need for include line

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Using the DSL you can:
 ``` ruby
 require "architecture/dsl"
 
+include Architecture
+
 architecture source: "old", destination: "new"  do |arc|
   # Filesystem transactions here, see below
 end


### PR DESCRIPTION
Hey!

Was setting up Architecture and it wasn't obvious that you need to include the Architecture module in a class as well as just requiring the DSL in order to get the 'architecture' method. Figured it out reading shogun source but probably something to add.
